### PR TITLE
LOOP-1964: rename glucoseTargetRangeScheduleApplyingOverrideIfActive to effectiveGlucoseTargetRangeSchedule

### DIFF
--- a/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
+++ b/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
@@ -118,7 +118,7 @@ extension StoredDosingDecision {
     
     var overrideStatus: NightscoutUploadKit.OverrideStatus {
         guard let scheduleOverride = scheduleOverride, scheduleOverride.isActive(),
-            let glucoseTargetRange = glucoseTargetRangeScheduleApplyingOverrideIfActive?.value(at: date) else
+            let glucoseTargetRange = effectiveGlucoseTargetRangeSchedule?.value(at: date) else
         {
             return NightscoutUploadKit.OverrideStatus(timestamp: date, active: false)
         }


### PR DESCRIPTION
See also https://github.com/tidepool-org/Loop/pull/283, https://github.com/tidepool-org/LoopKit/pull/259 